### PR TITLE
Fix seasonality extension.

### DIFF
--- a/es_rnn/model.py
+++ b/es_rnn/model.py
@@ -75,7 +75,8 @@ class ESRNN(nn.Module):
 
         if self.config['output_size'] > self.config['seasonality']:
             start_seasonality_ext = seasonalities_stacked.shape[1] - self.config['seasonality']
-            seasonalities_stacked = torch.cat((seasonalities_stacked, seasonalities_stacked[:, start_seasonality_ext:]),
+            end_seasonality_ext = start_seasonality_ext + self.config['output_size'] - self.config['seasonality']
+            seasonalities_stacked = torch.cat((seasonalities_stacked, seasonalities_stacked[:, start_seasonality_ext:end_seasonality_ext]),
                                               dim=1)
 
         window_input_list = []


### PR DESCRIPTION
This can append too many months to the seasonalities. In the case of 'Monthly' data, `config['output_size']` is 18, `config['seasonality']` is 12. If `seasonalities_stacked.shape[1]` is 72, `start_seasonality_ext` is 60, so line 89 appends 12 seasonalities, rather than 6 (as in the C++ dynet code).

```C++
 //if prediction horizon is larger than seasonality, so we need to repeat some of the seasonality factors
                if (OUTPUT_SIZE_I > SEASONALITY) {
                    unsigned long startSeasonalityIndx = season_exVect.size() - SEASONALITY;
                    for (int i = 0; i < (OUTPUT_SIZE_I - SEASONALITY); i++)
                        season_exVect.push_back(season_exVect[startSeasonalityIndx + i]);
                }
```

This becomes a problem on line 126 where we select the last `config['output_size']`, which will select the wrong `output_size` elements. In the case above, the seasonalities will be shifted by 6 months (18 - 12 = 6).